### PR TITLE
implicit conversion for play like html to string without having a dependency on the twirl api?

### DIFF
--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -24,6 +24,7 @@ object LibDependencies {
     "com.typesafe"            % "config"          % "1.4.1",
     "com.beachape"           %% "enumeratum"      % "1.7.0",
     "nu.validator"            % "validator"       % "20.7.2",
+    "com.typesafe.play"      %% "twirl-api"       % "1.5.1"   % "test",
     "com.vladsch.flexmark"    % "flexmark-all"    % "0.35.10" % "it,test",
     "com.softwaremill.diffx" %% "diffx-scalatest" % "0.5.6"   % "it,test"
   )

--- a/src/main/scala/uk/gov/hmrc/scalatestaccessibilitylinter/AccessibilityMatchers.scala
+++ b/src/main/scala/uk/gov/hmrc/scalatestaccessibilitylinter/AccessibilityMatchers.scala
@@ -23,9 +23,13 @@ import uk.gov.hmrc.scalatestaccessibilitylinter.config.{defaultAxeLinter, defaul
 import uk.gov.hmrc.scalatestaccessibilitylinter.domain._
 
 import scala.collection.immutable.ListMap
+import scala.language.{implicitConversions, reflectiveCalls}
 
 trait AccessibilityMatchers { this: Informing =>
   protected val accessibilityLinters: Seq[AccessibilityLinter.Service] = Seq(defaultAxeLinter, defaultVnuLinter)
+
+  private type PlayLikeWrappedHtml = { def body: String }
+  implicit def playLikeHtmlToString(html: PlayLikeWrappedHtml): String = html.body
 
   class PassAccessibilityChecksMatcher(accessibilityLinters: Seq[AccessibilityLinter.Service]) extends Matcher[String] {
     def apply(html: String): MatchResult = {


### PR DESCRIPTION
not sure if it's dangerous in some way I haven't considered but it popped into my head when I wanted to know if we could do structural types in scala and wanted to understand if it could be done. Raised as PR to see what other devs think and if I can learn something about why not to do this if there is something that makes this ill-advisable